### PR TITLE
Expandir guia de CMake para Geode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,52 @@ DecorationAssistant es un mod para [Geometry Dash](https://www.robtopgames.com/)
 
 4. Copia el paquete generado (`flozwer.decorationassistant.geode`) a tu carpeta de mods o utiliza `geode deploy`.
 
+### Problemas comunes con CMake
+
+Si al ejecutar CMake aparece un error similar a:
+
+```
+CMake Error at CMakeLists.txt:7 (find_package):
+  By not providing "FindGeode.cmake" in CMAKE_MODULE_PATH this project has
+  asked CMake to find a package configuration file provided by "Geode", but
+  CMake did not find one.
+```
+
+Verifica lo siguiente:
+
+1. **Geode SDK instalado**: confirma que seguiste la [guía de instalación](https://docs.geode-sdk.org/geode/getting-started/installation) y que la carpeta `geode-sdk` contiene los subdirectorios `lib`, `include` y `share`.
+2. **Variable `Geode_DIR`**: apunta CMake al archivo de configuración del SDK. Evita rutas con `~`; usa la ruta absoluta que
+   muestra `pwd` o el explorador de archivos.
+
+   ```bash
+   cmake -S . -B build -DGeode_DIR="/home/usuario/geode-sdk/share/cmake/Geode"
+   ```
+
+   En Windows (PowerShell):
+
+   ```powershell
+   cmake -S . -B build -G "Ninja" -DGeode_DIR="C:/Users/tuUsuario/geode-sdk/share/cmake/Geode"
+   ```
+
+   Si prefieres usar `CMAKE_PREFIX_PATH`, exporta/agrega el directorio `share/cmake` completo:
+
+   ```bash
+   export CMAKE_PREFIX_PATH="/home/usuario/geode-sdk/share/cmake:$CMAKE_PREFIX_PATH"
+   cmake -S . -B build
+   ```
+
+   ```powershell
+   $env:CMAKE_PREFIX_PATH="C:/Users/tuUsuario/geode-sdk/share/cmake;${env:CMAKE_PREFIX_PATH}"
+   cmake -S . -B build -G "Ninja"
+   ```
+
+3. **Verifica la ruta efectiva**: comprueba que `GeodeConfig.cmake` existe en la ruta especificada. Debe estar en
+   `geode-sdk/share/cmake/Geode/GeodeConfig.cmake`. Si no está, reinstala el SDK con `geode sdk install`.
+
+4. **Entorno limpio**: si el error persiste, borra la carpeta `build/` y vuelve a generar la configuración para asegurarte de que CMake recoja las nuevas rutas.
+
+Una vez que CMake encuentre el paquete `Geode`, el comando `ninja -C build` completará la compilación sin errores.
+
 ## Hotkeys y ajustes
 
 Los ajustes se exponen mediante Settings v3 en `mod.json`:


### PR DESCRIPTION
## Summary
- clarify how to pass an absolute Geode_DIR path on Linux and Windows
- document CMAKE_PREFIX_PATH examples for both shells
- add troubleshooting steps to verify GeodeConfig.cmake and reinstall the SDK if missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db17c8ccb08331abbf62045856b621