### PR TITLE
Agregar autodetección del SDK de Geode en CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,70 @@ project(DecorationAssistant)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Geode REQUIRED)
+# Try to auto-detect the Geode SDK if the user didn't set Geode_DIR manually.
+set(_GEODE_CANDIDATE_BASES)
+
+# Respect common environment variables that point to the SDK.
+foreach(_var IN ITEMS GEODE_SDK GEODE_SDK_PATH GEODE_SDK_ROOT GEODE_DIR)
+    if(DEFINED ENV{${_var}})
+        list(APPEND _GEODE_CANDIDATE_BASES "$ENV{${_var}}")
+    endif()
+endforeach()
+
+# Add a few conventional install locations as fallbacks.
+list(APPEND _GEODE_CANDIDATE_BASES "${CMAKE_SOURCE_DIR}/../geode-sdk")
+
+if(DEFINED ENV{HOME})
+    list(APPEND _GEODE_CANDIDATE_BASES "$ENV{HOME}/geode-sdk")
+endif()
+
+if(DEFINED ENV{LOCALAPPDATA})
+    list(APPEND _GEODE_CANDIDATE_BASES "$ENV{LOCALAPPDATA}/geode-sdk")
+endif()
+
+if(DEFINED ENV{USERPROFILE})
+    list(APPEND _GEODE_CANDIDATE_BASES "$ENV{USERPROFILE}/geode-sdk")
+endif()
+
+set(_GEODE_CONFIG_HINTS)
+foreach(_base IN LISTS _GEODE_CANDIDATE_BASES)
+    if(NOT _base)
+        continue()
+    endif()
+
+    # Normalize separators so CMake can reason about the path in a cross-platform way.
+    file(TO_CMAKE_PATH "${_base}" _normalized_base)
+
+    foreach(_suffix IN ITEMS "" "share/cmake/Geode" "cmake/Geode" "Geode")
+        set(_candidate "${_normalized_base}/${_suffix}")
+        if(EXISTS "${_candidate}/GeodeConfig.cmake")
+            list(APPEND _GEODE_CONFIG_HINTS "${_candidate}")
+        endif()
+    endforeach()
+endforeach()
+
+# Ensure Geode_DIR (if provided manually) takes precedence over auto-detected hints.
+if(DEFINED Geode_DIR)
+    list(PREPEND _GEODE_CONFIG_HINTS "${Geode_DIR}")
+endif()
+
+list(REMOVE_DUPLICATES _GEODE_CONFIG_HINTS)
+
+set(_GEODE_FIND_PACKAGE_ARGS CONFIG)
+if(_GEODE_CONFIG_HINTS)
+    list(APPEND _GEODE_FIND_PACKAGE_ARGS HINTS ${_GEODE_CONFIG_HINTS})
+endif()
+
+find_package(Geode QUIET ${_GEODE_FIND_PACKAGE_ARGS})
+
+if(NOT Geode_FOUND)
+    if(_GEODE_CONFIG_HINTS)
+        string(JOIN "\n  - " _GEODE_HINTS_MESSAGE ${_GEODE_CONFIG_HINTS})
+        message(FATAL_ERROR "No se pudo localizar el Geode SDK automáticamente. Se revisaron las rutas:\n  - ${_GEODE_HINTS_MESSAGE}\nDefine Geode_DIR manualmente o instala el SDK siguiendo https://docs.geode-sdk.org/")
+    else()
+        message(FATAL_ERROR "No se pudo localizar el Geode SDK. Define Geode_DIR o agrega el SDK a CMAKE_PREFIX_PATH. Consulta https://docs.geode-sdk.org/")
+    endif()
+endif()
 
 file(GLOB_RECURSE DECORATION_ASSISTANT_SOURCES
     CONFIGURE_DEPENDS

--- a/README.md
+++ b/README.md
@@ -29,6 +29,55 @@ DecorationAssistant es un mod para [Geometry Dash](https://www.robtopgames.com/)
 
 4. Copia el paquete generado (`flozwer.decorationassistant.geode`) a tu carpeta de mods o utiliza `geode deploy`.
 
+### Problemas comunes con CMake
+
+Si al ejecutar CMake aparece un error similar a:
+
+```
+CMake Error at CMakeLists.txt:7 (find_package):
+  By not providing "FindGeode.cmake" in CMAKE_MODULE_PATH this project has
+  asked CMake to find a package configuration file provided by "Geode", but
+  CMake did not find one.
+```
+
+Verifica lo siguiente:
+
+1. **Geode SDK instalado**: confirma que seguiste la [guía de instalación](https://docs.geode-sdk.org/geode/getting-started/installation) y que la carpeta `geode-sdk` contiene los subdirectorios `lib`, `include` y `share`.
+2. **Detección automática**: el `CMakeLists.txt` intentará resolver el SDK leyendo las variables de entorno `GEODE_SDK`,
+   `GEODE_SDK_PATH`, `GEODE_SDK_ROOT` o `Geode_DIR`, además de rutas comunes (`~/geode-sdk`, `%LOCALAPPDATA%/geode-sdk`, etc.).
+   Si el SDK está instalado ahí, no necesitas pasar flags adicionales.
+3. **Variable `Geode_DIR`**: si la autodetección no funciona, apunta CMake al archivo de configuración del SDK. Evita rutas con
+   `~`; usa la ruta absoluta que muestra `pwd` o el explorador de archivos.
+
+   ```bash
+   cmake -S . -B build -DGeode_DIR="/home/usuario/geode-sdk/share/cmake/Geode"
+   ```
+
+   En Windows (PowerShell):
+
+   ```powershell
+   cmake -S . -B build -G "Ninja" -DGeode_DIR="C:/Users/tuUsuario/geode-sdk/share/cmake/Geode"
+   ```
+
+   Si prefieres usar `CMAKE_PREFIX_PATH`, exporta/agrega el directorio `share/cmake` completo:
+
+   ```bash
+   export CMAKE_PREFIX_PATH="/home/usuario/geode-sdk/share/cmake:$CMAKE_PREFIX_PATH"
+   cmake -S . -B build
+   ```
+
+   ```powershell
+   $env:CMAKE_PREFIX_PATH="C:/Users/tuUsuario/geode-sdk/share/cmake;${env:CMAKE_PREFIX_PATH}"
+   cmake -S . -B build -G "Ninja"
+   ```
+
+4. **Verifica la ruta efectiva**: comprueba que `GeodeConfig.cmake` existe en la ruta especificada. Debe estar en
+   `geode-sdk/share/cmake/Geode/GeodeConfig.cmake`. Si no está, reinstala el SDK con `geode sdk install`.
+
+5. **Entorno limpio**: si el error persiste, borra la carpeta `build/` y vuelve a generar la configuración para asegurarte de que CMake recoja las nuevas rutas.
+
+Una vez que CMake encuentre el paquete `Geode`, el comando `ninja -C build` completará la compilación sin errores.
+
 ## Hotkeys y ajustes
 
 Los ajustes se exponen mediante Settings v3 en `mod.json`:


### PR DESCRIPTION
## Summary
- add auto-detection logic for the Geode SDK in CMake, checking common environment variables and install paths before failing with a clearer message
- update the troubleshooting section in the README to explain the new automatic detection and refreshed steps

## Testing
- cmake -S . -B build *(fails: Geode SDK not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db17c8ccb08331abbf62045856b621