### PR TITLE
Add GD compatibility section to mod manifest

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -5,6 +5,11 @@
   "name": "Decoration Assistant",
   "developer": "flozwer",
   "description": "Asistente inteligente de decoración para el Editor de Geometry Dash.",
+  "gd": {
+    "platforms": {
+      "win": ["2.2"]
+    }
+  },
   "dependencies": [
     {
       "id": "geode.node-ids",


### PR DESCRIPTION
## Summary
- add the required `gd` section to the manifest so Geode 4.8.0 can parse it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db222011288331a7e19c7ae26230bc