### PR TITLE
Fix Windows GD version specification in mod.json

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -6,9 +6,7 @@
   "developer": "flozwer",
   "description": "Asistente inteligente de decoración para el Editor de Geometry Dash.",
   "gd": {
-    "platforms": {
-      "win": ["2.2"]
-    }
+    "win": "2.2"
   },
   "dependencies": [
     {


### PR DESCRIPTION
## Summary
- update the mod manifest to declare the Windows Geometry Dash version directly instead of as a list entry

## Testing
- not run (manifest-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db23c344048331b66b1f83ac5a844a