### PR TITLE
Fix EditorScan missing includes

### DIFF
--- a/src/core/EditorScan.cpp
+++ b/src/core/EditorScan.cpp
@@ -1,6 +1,9 @@
 #include "EditorScan.hpp"
 #include "../integration/EditorAdapter.hpp"
 
+#include <Geode/utils/cocos.hpp>
+#include <fmt/format.h>
+
 using namespace geode::prelude;
 
 namespace DecorationAssistant::Core {


### PR DESCRIPTION
## Summary
- include the cocos utility helpers and fmt headers for EditorScan
- fix compilation issues when building EditorScan.cpp

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db27af66ec8331a235ea330454c3ba