### PR TITLE
Add missing include for Color utility

### DIFF
--- a/src/utils/Color.cpp
+++ b/src/utils/Color.cpp
@@ -1,4 +1,5 @@
 #include "Color.hpp"
+#include <sstream>
 
 namespace DecorationAssistant::Utils {
 


### PR DESCRIPTION
## Summary
- include `<sstream>` in `Color.cpp` so `std::stringstream` is declared

## Testing
- `cmake -S . -B build` *(fails: Geode SDK not found in environment)*
- `cmake -S . -B build -DDA_FETCH_GEODE=ON` *(fails: unable to download Geode SDK due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68db2a7cb0748331b938eb9e140f3e8b