### PR TITLE
Fix invalid JSON warning placeholder

### DIFF
--- a/src/core/RuleEngine.cpp
+++ b/src/core/RuleEngine.cpp
@@ -16,7 +16,7 @@ void RuleEngine::loadFromFile(const std::filesystem::path& path) {
     }
     auto json = Utils::jsonFromString(*raw);
     if (!json) {
-        log::warn("RuleEngine: invalid JSON {}");
+        log::warn("RuleEngine: invalid JSON {}", path.string());
         return;
     }
     if (!json->contains("rules")) {


### PR DESCRIPTION
## Summary
- include the file path when logging invalid JSON to avoid fmt placeholder mismatches

## Testing
- cmake -S . -B build *(fails: Geode SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db2ae32eb08331958ab5bd3f3366cd