### PR TITLE
Implement suggestion creation commands

### DIFF
--- a/src/core/ApplyEngine.cpp
+++ b/src/core/ApplyEngine.cpp
@@ -1,10 +1,112 @@
 #include "ApplyEngine.hpp"
 #include "UndoManager.hpp"
+#include <Geode/binding/GameObject.hpp>
+#include <Geode/binding/LevelEditorLayer.hpp>
+#include <algorithm>
+#include <cmath>
+#include <fmt/format.h>
 #include <memory>
+#include <optional>
+#include <string_view>
 
 using namespace geode::prelude;
 
 namespace DecorationAssistant::Core {
+
+namespace {
+
+int suggestionDefaultObjectID(SuggestionType type) {
+    switch (type) {
+        case SuggestionType::Border:
+            return 1; // simple block
+        case SuggestionType::BackgroundDetail:
+            return 744; // decorative detail
+        case SuggestionType::Particle:
+            return 2065; // particle emitter
+        case SuggestionType::Pulse:
+            return 1006; // color trigger
+        case SuggestionType::Glow:
+            return 841; // glow piece
+        case SuggestionType::ThemeElement:
+            return 2903; // themed deco
+        case SuggestionType::Trigger:
+            return 1000; // generic trigger
+    }
+    return 1;
+}
+
+std::optional<float> findNumeric(const Suggestion& suggestion, std::string_view key) {
+    auto it = suggestion.numericParams.find(std::string(key));
+    if (it != suggestion.numericParams.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::optional<int> findIntNumeric(const Suggestion& suggestion, std::string_view key) {
+    if (auto value = findNumeric(suggestion, key)) {
+        return static_cast<int>(std::lround(*value));
+    }
+    return std::nullopt;
+}
+
+std::optional<int> findIntString(const Suggestion& suggestion, std::string_view key) {
+    auto it = suggestion.stringParams.find(std::string(key));
+    if (it == suggestion.stringParams.end()) {
+        return std::nullopt;
+    }
+    try {
+        return std::stoi(it->second);
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::vector<GameObject*> buildObjectsForSuggestion(const Suggestion& suggestion) {
+    std::vector<GameObject*> objects;
+
+    int objectID = suggestionDefaultObjectID(suggestion.type);
+    if (auto id = findIntNumeric(suggestion, "object_id")) {
+        objectID = *id;
+    } else if (auto id = findIntNumeric(suggestion, "objectID")) {
+        objectID = *id;
+    } else if (auto id = findIntString(suggestion, "object_id")) {
+        objectID = *id;
+    } else if (auto id = findIntString(suggestion, "objectID")) {
+        objectID = *id;
+    } else if (auto id = findIntString(suggestion, "object")) {
+        objectID = *id;
+    }
+
+    auto* object = GameObject::createWithKey(objectID);
+    if (!object) {
+        return objects;
+    }
+
+    const auto bounds = suggestion.region.bounds;
+    float posX = bounds.getMidX();
+    float posY = bounds.getMidY();
+    if (auto val = findNumeric(suggestion, "x")) posX = *val;
+    if (auto val = findNumeric(suggestion, "y")) posY = *val;
+    object->setPosition({posX, posY});
+
+    if (auto val = findNumeric(suggestion, "scale")) object->setScale(*val);
+    if (auto val = findNumeric(suggestion, "scaleX")) object->setScaleX(*val);
+    if (auto val = findNumeric(suggestion, "scaleY")) object->setScaleY(*val);
+    if (auto val = findNumeric(suggestion, "rotation")) object->setRotation(*val);
+    if (auto val = findNumeric(suggestion, "opacity")) object->setOpacity(static_cast<GLubyte>(std::clamp(*val, 0.f, 255.f)));
+
+    if (suggestion.palette) {
+        const auto& base = suggestion.palette->base;
+        object->setColor({base.r, base.g, base.b});
+        object->setOpacity(base.a);
+    }
+
+    objects.push_back(object);
+    return objects;
+}
+
+} // namespace
 
 ApplyReport ApplyEngine::apply(LevelEditorLayer* layer, const std::vector<Suggestion>& suggestions, bool previewOnly) {
     ApplyReport report;
@@ -12,14 +114,43 @@ ApplyReport ApplyEngine::apply(LevelEditorLayer* layer, const std::vector<Sugges
         return report;
     }
 
+    if (previewOnly) {
+        report.label = "Autodeco preview";
+        return report;
+    }
+
     auto composite = std::make_shared<CompositeCommand>("Autodeco batch");
     for (auto& suggestion : suggestions) {
-        auto cmd = std::make_shared<CreateObjectsCommand>();
-        cmd->label = suggestion.rationale;
-        if (!previewOnly) {
-            report.createdObjects += 1;
+        auto objects = buildObjectsForSuggestion(suggestion);
+        if (objects.empty()) {
+            continue;
         }
+
+        auto cmd = std::make_shared<CreateObjectsCommand>();
+        cmd->label = suggestion.rationale.empty() ? "Crear objeto" : suggestion.rationale;
+        cmd->layer = layer;
+
+        for (auto* obj : objects) {
+            if (!obj) continue;
+            obj->retain();
+            cmd->created.push_back(obj);
+        }
+
+        if (cmd->created.empty()) {
+            continue;
+        }
+
+        cmd->apply();
+        report.createdObjects += cmd->created.size();
         composite->commands.push_back(cmd);
+    }
+
+    if (composite->commands.empty()) {
+        return report;
+    }
+
+    if (report.createdObjects > 0) {
+        composite->label = fmt::format("Autodeco: {} objetos", report.createdObjects);
     }
     UndoManager::get().push(composite);
     report.label = composite->label;

--- a/src/core/UndoCommands.cpp
+++ b/src/core/UndoCommands.cpp
@@ -1,0 +1,44 @@
+#include "UndoManager.hpp"
+#include <Geode/binding/GameObject.hpp>
+#include <Geode/binding/LevelEditorLayer.hpp>
+
+using namespace geode::prelude;
+
+namespace DecorationAssistant::Core {
+
+CreateObjectsCommand::~CreateObjectsCommand() {
+    for (auto* obj : created) {
+        if (obj) {
+            obj->release();
+        }
+    }
+}
+
+void CreateObjectsCommand::apply() {
+    if (!layer) {
+        return;
+    }
+    for (auto* obj : created) {
+        if (!obj) continue;
+        if (obj->getParent()) {
+            continue;
+        }
+        layer->addObject(obj);
+    }
+}
+
+void CreateObjectsCommand::revert() {
+    if (!layer) {
+        return;
+    }
+    for (auto* obj : created) {
+        if (!obj) continue;
+        if (!obj->getParent()) {
+            continue;
+        }
+        layer->removeObject(obj, true);
+    }
+}
+
+} // namespace DecorationAssistant::Core
+

--- a/src/core/UndoManager.hpp
+++ b/src/core/UndoManager.hpp
@@ -24,9 +24,13 @@ public:
 
 class CreateObjectsCommand : public ICommand {
 public:
+    LevelEditorLayer* layer = nullptr;
     std::vector<GameObject*> created;
-    void apply() override {}
-    void revert() override {}
+
+    ~CreateObjectsCommand() override;
+
+    void apply() override;
+    void revert() override;
 };
 
 class DeleteObjectsCommand : public ICommand {


### PR DESCRIPTION
## Summary
- create real GameObjects for each suggestion in the apply engine and configure basic transforms
- implement CreateObjectsCommand logic to add/remove created objects so undo and redo work
- update apply reporting to reflect the number of objects created and label batches accordingly

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db2b3fdb6083319c3588bdd9309e23