### PR TITLE
Fix missing includes for optional and json

### DIFF
--- a/src/core/LayerAssigner.cpp
+++ b/src/core/LayerAssigner.cpp
@@ -1,7 +1,9 @@
 #include "LayerAssigner.hpp"
 #include "../utils/Json.hpp"
 #include <Geode/utils/file.hpp>
+#include <algorithm>
 #include <fmt/format.h>
+#include <memory>
 
 using namespace geode::prelude;
 

--- a/src/core/LayerAssigner.hpp
+++ b/src/core/LayerAssigner.hpp
@@ -3,6 +3,8 @@
 #include <Geode/Geode.hpp>
 #include "UndoManager.hpp"
 #include <filesystem>
+#include <optional>
+#include <utility>
 
 namespace DecorationAssistant::Core {
 

--- a/src/core/PaletteEngine.cpp
+++ b/src/core/PaletteEngine.cpp
@@ -1,6 +1,8 @@
 #include "PaletteEngine.hpp"
 #include "../utils/Json.hpp"
 #include <Geode/utils/file.hpp>
+#include <cmath>
+#include <limits>
 #include <sstream>
 
 using namespace geode::prelude;

--- a/src/core/PaletteEngine.hpp
+++ b/src/core/PaletteEngine.hpp
@@ -2,6 +2,7 @@
 
 #include "Suggestion.hpp"
 #include <filesystem>
+#include <optional>
 
 namespace DecorationAssistant::Core {
 

--- a/src/core/RuleEngine.hpp
+++ b/src/core/RuleEngine.hpp
@@ -3,7 +3,9 @@
 #include "Suggestion.hpp"
 #include "EditorScan.hpp"
 #include <filesystem>
+#include <optional>
 #include <random>
+#include <nlohmann/json_fwd.hpp>
 
 namespace DecorationAssistant::Core {
 

--- a/src/utils/Json.hpp
+++ b/src/utils/Json.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Geode/Geode.hpp>
+#include <nlohmann/json.hpp>
 #include <optional>
 
 namespace DecorationAssistant::Utils {


### PR DESCRIPTION
## Summary
- include the nlohmann json headers where json types are used
- add missing standard library headers required for optional, algorithm, limits, and memory utilities
- ensure palette and layer engines have the necessary math and utility includes

## Testing
- cmake -S . -B build *(fails: Geode SDK not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db2d137fac8331a9eee8fdeb12324a